### PR TITLE
Fix for upf build

### DIFF
--- a/src/upf/lib/gtpv1/CMakeLists.txt
+++ b/src/upf/lib/gtpv1/CMakeLists.txt
@@ -30,3 +30,19 @@ add_custom_target(libgtp5gnl ALL
 )
 
 link_directories("${CMAKE_SOURCE_DIR}/lib" "${LIBGTP5GNL_DST}/lib" ${LOGGER_DST})
+
+# Test
+add_executable("${PROJECT_NAME}_test" test.c)
+set_target_properties("${PROJECT_NAME}_test" PROPERTIES
+    OUTPUT_NAME "${BUILD_BIN_DIR}/testgtpv1"
+)
+
+target_link_libraries("${PROJECT_NAME}_test" free5GC_lib gtp5gnl logger mnl)
+target_include_directories("${PROJECT_NAME}_test" PRIVATE
+    include
+    ${LOGGER_DST}
+    "${LIBGTP5GNL_DST}/include"
+    "${CMAKE_SOURCE_DIR}/lib/utlt/include"
+)
+target_compile_options("${PROJECT_NAME}_test" PRIVATE -Wall -Werror)
+add_dependencies("${PROJECT_NAME}_test" utlt_logger libgtp5gnl)

--- a/src/upf/lib/libgtp5gnl/m4/gcc4_visibility.m4
+++ b/src/upf/lib/libgtp5gnl/m4/gcc4_visibility.m4
@@ -1,0 +1,21 @@
+
+# GCC 4.x -fvisibility=hidden
+
+AC_DEFUN([CHECK_GCC_FVISIBILITY], [
+	AC_LANG_PUSH([C])
+	saved_CFLAGS="$CFLAGS"
+	CFLAGS="$saved_CFLAGS -fvisibility=hidden"
+	AC_CACHE_CHECK([whether compiler accepts -fvisibility=hidden],
+	  [ac_cv_fvisibility_hidden], AC_COMPILE_IFELSE(
+		[AC_LANG_SOURCE()],
+		[ac_cv_fvisibility_hidden=yes],
+		[ac_cv_fvisibility_hidden=no]
+	))
+	if test "$ac_cv_fvisibility_hidden" = "yes"; then
+		AC_DEFINE([HAVE_VISIBILITY_HIDDEN], [1],
+			[True if compiler supports -fvisibility=hidden])
+		AC_SUBST([GCC_FVISIBILITY_HIDDEN], [-fvisibility=hidden])
+	fi
+	CFLAGS="$saved_CFLAGS"
+	AC_LANG_POP([C])
+])


### PR DESCRIPTION
The following fixes have been added to the build error in UPF

* Add testgtpv1 building rules as well as stage-2.
* Add m4/gcc4_visibility.m4 as same as stage-2.